### PR TITLE
vold: Remove duplicate attempt to open LUN path

### DIFF
--- a/VolumeManager.cpp
+++ b/VolumeManager.cpp
@@ -1624,11 +1624,6 @@ int VolumeManager::shareVolume(const char *label, const char *method) {
         }
     }
 
-    if ((fd = open(MASS_STORAGE_FILE_PATH, O_WRONLY)) < 0) {
-        SLOGE("Unable to open ums lunfile (%s)", strerror(errno));
-        return -1;
-    }
-
     if (write(fd, nodepath, strlen(nodepath)) < 0) {
         SLOGE("Unable to write to ums lunfile (%s)", strerror(errno));
         close(fd);


### PR DESCRIPTION
Commit 'Changes for supporting UICC feature' errantly duplicated the LUN
open attempt instead of moving into the if/else logic.

Change-Id: Id56f53e4048a1701b51b70c1cbc8b82b93a607a7
