### PR TITLE
vold: support more than 1 UMS share

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -79,6 +79,10 @@ ifeq ($(BOARD_VOLD_DISC_HAS_MULTIPLE_MAJORS), true)
 common_cflags += -DVOLD_DISC_HAS_MULTIPLE_MAJORS
 endif
 
+ifneq ($(TARGET_USE_CUSTOM_LUN_FILE_PATH),)
+common_cflags += -DCUSTOM_LUN_FILE=\"$(TARGET_USE_CUSTOM_LUN_FILE_PATH)\"
+endif
+
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := libvold

--- a/Volume.cpp
+++ b/Volume.cpp
@@ -128,6 +128,7 @@ Volume::Volume(VolumeManager *vm, const fstab_rec* rec, int flags) {
     mCurrentlyMountedKdev = -1;
     mPartIdx = rec->partnum;
     mRetryMount = false;
+    mLunNumber = -1;
 }
 
 Volume::~Volume() {

--- a/Volume.h
+++ b/Volume.h
@@ -58,6 +58,7 @@ protected:
     int mPartIdx;
     int mOrigPartIdx;
     bool mRetryMount;
+    int mLunNumber;
 
     /*
      * The major/minor tuple of the currently mounted filesystem.
@@ -77,6 +78,9 @@ public:
     const char* getUserLabel() { return mUserLabel; }
     int getState() { return mState; }
     int getFlags() { return mFlags; };
+
+    int getLunNumber() { return mLunNumber; }
+    void setLunNumber(int lunNumber) { mLunNumber = lunNumber; }
 
     /* Mountpoint of the raw volume */
     virtual const char *getMountpoint() = 0;

--- a/VolumeManager.cpp
+++ b/VolumeManager.cpp
@@ -53,7 +53,6 @@
 #include "Asec.h"
 #include "cryptfs.h"
 
-#define MASS_STORAGE_FILE_PATH  "/sys/class/android_usb/android0/f_mass_storage/lun/file"
 #define UICC0_MASS_STORAGE_PATH  "/sys/class/android_usb/android0/f_mass_storage/uicc0/file"
 
 #define ROUND_UP_POWER_OF_2(number, po2) (((!!(number & ((1U << po2) - 1))) << po2)\
@@ -244,6 +243,7 @@ int VolumeManager::addVolume(Volume *v) {
         }
     }
 
+    v->setLunNumber(mVolumes->size());
     mVolumes->push_back(v);
     return 0;
 }
@@ -1549,6 +1549,36 @@ int VolumeManager::shareEnabled(const char *label, const char *method, bool *ena
     return 0;
 }
 
+static const char *LUN_FILES[] = {
+#ifdef CUSTOM_LUN_FILE
+    CUSTOM_LUN_FILE,
+#endif
+    /* Only android0 exists, but the %d in there is a hack to satisfy the
+       format string and also give a not found error when %d > 0 */
+    "/sys/class/android_usb/android%d/f_mass_storage/lun/file",
+    NULL
+};
+
+int VolumeManager::openLun(int number) {
+    const char **iterator = LUN_FILES;
+    char qualified_lun[255];
+    while (*iterator) {
+        bzero(qualified_lun, 255);
+        snprintf(qualified_lun, 254, *iterator, number);
+        int fd = open(qualified_lun, O_WRONLY);
+        if (fd >= 0) {
+            SLOGD("Opened lunfile %s", qualified_lun);
+            return fd;
+        }
+        SLOGE("Unable to open ums lunfile %s (%s)", qualified_lun, strerror(errno));
+        iterator++;
+    }
+
+    errno = EINVAL;
+    SLOGE("Unable to find ums lunfile for LUN %d", number);
+    return -1;
+}
+
 int VolumeManager::shareVolume(const char *label, const char *method) {
     Volume *v = lookupVolume(label);
 
@@ -1618,10 +1648,8 @@ int VolumeManager::shareVolume(const char *label, const char *method) {
             return -1;
         }
     } else {
-        if ((fd = open(MASS_STORAGE_FILE_PATH, O_WRONLY)) < 0) {
-            SLOGE("Unable to open ums lunfile (%s)", strerror(errno));
+        if ((fd = openLun(v->getLunNumber())) < 0)
             return -1;
-        }
     }
 
     if (write(fd, nodepath, strlen(nodepath)) < 0) {
@@ -1669,10 +1697,8 @@ int VolumeManager::unshareVolume(const char *label, const char *method) {
     }
 
     int fd;
-    if ((fd = open(MASS_STORAGE_FILE_PATH, O_WRONLY)) < 0) {
-        SLOGE("Unable to open ums lunfile (%s)", strerror(errno));
+    if ((fd = openLun(v->getLunNumber())) < 0)
         return -1;
-    }
 
     char ch = 0;
     if (write(fd, &ch, 1) < 0) {
@@ -1880,6 +1906,11 @@ int VolumeManager::cleanupAsec(Volume *v, bool force) {
 
     AsecIdCollection removeAsec;
     AsecIdCollection removeObb;
+
+    // Only primary storage needs ASEC cleanup
+    if (!(v->getFlags() & VOL_PROVIDES_ASEC)) {
+        return 0;
+    }
 
     for (AsecIdCollection::iterator it = mActiveContainers->begin(); it != mActiveContainers->end();
             ++it) {

--- a/VolumeManager.h
+++ b/VolumeManager.h
@@ -156,6 +156,7 @@ private:
     bool isMountpointMounted(const char *mp);
     bool isAsecInDirectory(const char *dir, const char *asec) const;
     bool isLegalAsecId(const char *id) const;
+    int openLun(int number);
 };
 
 extern "C" {


### PR DESCRIPTION
Used for devices with both mountable internal and external sdcards.

This is a forward-port and clean up of the 10.2 code (which contains
a lot of deadcode.)

Original authors:

```
Alex Zepeda <alex@inferiorhumanorgans.com>
Genokolar <genokolar@gmail.com>
Josh Stone <cuviper@gmail.com>
mik_os <kiril.mik.os@gmail.com>
Oran Avraham <oranav@gmail.com>
Pawit Pornkitprasan <p.pawit@gmail.com>
Tony Layher <layhertony@gmail.com>
```

Change-Id: I926ce244255414697373d26d252a9da89aea7226
